### PR TITLE
add ghostty config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CONFIGS = \
 Xdefaults \
 Xmodmap \
 config/awesome/rc.lua \
+config/ghostty/config \
 gitconfig \
 screenrc \
 tmux.conf \

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,0 +1,5 @@
+theme = light:iTerm2 Solarized Light,dark:iTerm2 Solarized Dark
+macos-non-native-fullscreen = true
+font-family = JetBrainsMono Nerd Font Mono
+font-size = 12
+shell-integration-features = ssh-terminfo,ssh-env


### PR DESCRIPTION
Adds my Ghostty terminal config to the dotfiles repo, following the existing symlink-based convention.

## Changes
- **`config/ghostty/config`** — Ghostty settings (Solarized light/dark theme switching, JetBrainsMono Nerd Font, non-native fullscreen, SSH shell integration), copied verbatim from `~/.config/ghostty/config`.
- **`Makefile`** — registered `config/ghostty/config` in the `CONFIGS` list. The generic symlink rule resolves it to `~/.config/ghostty/config`, mirroring the existing `config/awesome/rc.lua` precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)