### PR TITLE
Track ghostty config and add quick terminal keybind

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -2,4 +2,8 @@ theme = light:iTerm2 Solarized Light,dark:iTerm2 Solarized Dark
 macos-non-native-fullscreen = true
 font-family = JetBrainsMono Nerd Font Mono
 font-size = 12
-shell-integration-features = ssh-terminfo,ssh-env
+shell-integration-features = no-cursor,ssh-terminfo,ssh-env
+
+# Toggle the Quake-style quick terminal from anywhere (Cmd+`).
+# `global:` requires Accessibility permissions for Ghostty on macOS.
+keybind = global:cmd+backquote=toggle_quick_terminal


### PR DESCRIPTION
## Summary
- Bring `~/.config/ghostty/config` into the dotfiles repo at `config/ghostty/config` so it's version-controlled like the rest of the dotfiles.
- Wire it into the `Makefile` `CONFIGS` list — the existing `$(DEST)/.%` rule will symlink `config/ghostty/config` → `~/.config/ghostty/config` on `make install` (backing up any existing real file to `*.bak` first).
- Add a global keybind to toggle the Quake-style quick terminal with `Cmd+\``.

## Notes
- The `global:` trigger prefix means the keybind fires even when Ghostty isn't focused. On macOS this requires granting Ghostty **Accessibility** permission (System Settings → Privacy & Security → Accessibility); macOS will prompt on first use.
- Keybind syntax (`global:cmd+backquote=toggle_quick_terminal`) confirmed against the [Ghostty keybind reference](https://ghostty.org/docs/config/keybind/reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)