### PR TITLE
incorporating zmx

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -3,6 +3,7 @@ if [ -x /usr/libexec/path_helper ]; then
 fi
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
+export ZMX_SESSION_PREFIX="d."
 
 fpath=($fpath $HOME/.zsh/func)
 for f in $HOME/.zsh/func/* $HOME/.zsh/func/*/*; do

--- a/zshprompt
+++ b/zshprompt
@@ -180,7 +180,7 @@ add-zsh-hook precmd gitinfo_precmd
 PS1='%F{yellow}[%T%F{cyan}%1(j.%%%F{green}%j%F{cyan}.)%0(?..:%F{red}%B%?%b)%F{yellow}]%F{cyan}%# %f'
 zmx_rps=""
 if [[ -n $ZMX_SESSION ]]; then
-	zmx_rps="%F{magenta}$ZMX_SESSION%f "
+	zmx_rps="%F{magenta}[$ZMX_SESSION]%f "
 fi
 RPS1='${zmx_rps}%100>..>%F{cyan}%n%f%B@%b%F{cyan}%m%f%B:%b%<<%F{cyan}$(git_path)$gitinfo[msg]%b%k%f'
 

--- a/zshprompt
+++ b/zshprompt
@@ -178,5 +178,9 @@ add-zsh-hook preexec gitinfo_preexec
 add-zsh-hook precmd gitinfo_precmd
 
 PS1='%F{yellow}[%T%F{cyan}%1(j.%%%F{green}%j%F{cyan}.)%0(?..:%F{red}%B%?%b)%F{yellow}]%F{cyan}%# %f'
-RPS1='%100>..>%F{cyan}%n%f%B@%b%F{cyan}%m%f%B:%b%<<%F{cyan}$(git_path)$gitinfo[msg]%b%k%f'
+zmx_rps=""
+if [[ -n $ZMX_SESSION ]]; then
+	zmx_rps="%F{magenta}$ZMX_SESSION%f "
+fi
+RPS1='${zmx_rps}%100>..>%F{cyan}%n%f%B@%b%F{cyan}%m%f%B:%b%<<%F{cyan}$(git_path)$gitinfo[msg]%b%k%f'
 

--- a/zshprompt
+++ b/zshprompt
@@ -180,7 +180,7 @@ add-zsh-hook precmd gitinfo_precmd
 PS1='%F{yellow}[%T%F{cyan}%1(j.%%%F{green}%j%F{cyan}.)%0(?..:%F{red}%B%?%b)%F{yellow}]%F{cyan}%# %f'
 zmx_rps=""
 if [[ -n $ZMX_SESSION ]]; then
-	zmx_rps="%F{magenta}[$ZMX_SESSION]%f "
+	zmx_rps="%F{magenta}[${ZMX_SESSION#$ZMX_SESSION_PREFIX}]%f "
 fi
 RPS1='${zmx_rps}%100>..>%F{cyan}%n%f%B@%b%F{cyan}%m%f%B:%b%<<%F{cyan}$(git_path)$gitinfo[msg]%b%k%f'
 

--- a/zshrc
+++ b/zshrc
@@ -403,6 +403,55 @@ bind-git-helper() {
 }
 bind-git-helper f b t r h
 unset -f bind-git-helper
+
+# zmx session picker: fuzzy-find/attach/create a zmx session (Ctrl-P)
+zmx-select() {
+  local display
+  display=$(zmx list 2>/dev/null | while IFS=$'\t' read -r name pid clients created dir; do
+    name=${name#*name=}
+    pid=${pid#*pid=}
+    clients=${clients#*clients=}
+    dir=${dir#*start_dir=}
+    printf "%-20s  pid:%-8s  clients:%-2s  %s\n" "$name" "$pid" "$clients" "$dir"
+  done)
+
+  local output query key selected session_name
+  output=$({ [[ -n "$display" ]] && echo "$display"; } | fzf \
+    --print-query \
+    --expect=ctrl-n \
+    --height=80% \
+    --reverse \
+    --prompt="zmx> " \
+    --header="Enter: select | Ctrl-N: create new" \
+    --preview='zmx history {1}' \
+    --preview-window=right:60%:follow \
+  )
+  local rc=$?
+
+  query=$(echo "$output" | sed -n '1p')
+  key=$(echo "$output" | sed -n '2p')
+  selected=$(echo "$output" | sed -n '3p')
+
+  if [[ "$key" == "ctrl-n" && -n "$query" ]]; then
+    session_name="$query"
+  elif [[ $rc -eq 0 && -n "$selected" ]]; then
+    session_name=$(echo "$selected" | awk '{print $1}')
+  elif [[ -n "$query" ]]; then
+    session_name="$query"
+  else
+    return 130
+  fi
+
+  zmx attach "$session_name"
+}
+
+zmx-select-widget() {
+  zle push-input
+  BUFFER="zmx-select"
+  zle accept-line
+}
+zle -N zmx-select-widget
+bindkey '^p' zmx-select-widget
 #}}}
 
 # must be at end of file


### PR DESCRIPTION
## What

When inside a [`zmx`](https://github.com/gideonite) session, show the session name on the right-hand prompt (`RPROMPT`) in magenta. Outside a session the prompt is unchanged.

`zmx` injects `ZMX_SESSION` into the session shell's environment, so a simple `[[ -n $ZMX_SESSION ]]` guard drives the indicator. The segment sits at the left end of `RPROMPT`, before `user@host`, and outside the `%100>..>…%<<` truncation window so a long git path can't truncate it away.

## Why the variable instead of inline `${ZMX_SESSION:+…}`

The `%F{magenta}` prompt escape contains literal `{ }`, which breaks `${ZMX_SESSION:+word}` brace matching (zsh matches the first `}`, inside `%F{magenta}`). Building the segment into `zmx_rps` and referencing it in the single-quoted `RPS1` (expanded each render via the already-enabled `promptsubst`) sidesteps that.

## Testing

- `ZMX_SESSION=demo zsh -f -c 'autoload -Uz add-zsh-hook; setopt promptsubst; source ./zshprompt; print -rP -- "$RPS1"'` → renders magenta session name.
- Same with `env -u ZMX_SESSION` → no zmx segment, prompt unchanged.
- Live check inside `zmx attach test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)