### PR TITLE
Add Claude Code config with zmx terminal session guidance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DEST = $(HOME)
 CONFIGS = \
 Xdefaults \
 Xmodmap \
+claude/CLAUDE.md \
 config/awesome/rc.lua \
 config/ghostty/config \
 gitconfig \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,14 @@ ZSHBUNDLES = $(patsubst %,zsh/func/%/.git,$(ZSHBUNDLEFILES))
 
 all: build
 
-install: build $(TARGETS)
+install: build $(TARGETS) $(DEST)/.claude/CLAUDE.local.md
+
+# Per-machine Claude instructions, imported by ~/.claude/CLAUDE.md.
+# Created empty when absent and never overwritten, so each machine keeps
+# its own overrides.
+$(DEST)/.claude/CLAUDE.local.md:
+	@mkdir -p $(dir $@)
+	touch $@
 
 $(DEST)/.% : %
 	@mkdir -p $(dir $@)

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -1,0 +1,21 @@
+# Global instructions for Claude Code
+
+## Terminal sessions: use zmx
+
+zmx (https://zmx.sh) provides persistent detached terminal sessions.
+Use it for long-running commands.
+
+Before using zmx, run `zmx help` to get current syntax — it changes
+between versions, so derive the commands from help rather than assuming.
+
+Session naming:
+- Prefix all agent-spawned sessions with `ai.` so they're separate
+  from the user's own sessions. Never kill the user's sessions.
+- Scope related sessions under a shared sub-prefix per task/feature.
+  Working on feature X → name sessions `ai.feature-x`, `ai.feature-x.tests`, etc.
+- When cleaning up, kill only the relevant group, not everything:
+  `zmx kill "ai.feature-x.*"` — not `zmx kill "ai.*"`.
+
+Remote machines:
+- When working on a remote machine, use zmx sessions there too, with
+  the same `ai.` prefix and per-feature scoping rules.

--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -19,3 +19,13 @@ Session naming:
 Remote machines:
 - When working on a remote machine, use zmx sessions there too, with
   the same `ai.` prefix and per-feature scoping rules.
+
+## Machine-specific instructions
+
+Anything specific to one machine — work setup on a dev box, personal
+setup on a laptop — goes in `~/.claude/CLAUDE.local.md`, which is not
+tracked in this repo. `make install` creates it empty and never
+overwrites it, so each machine keeps its own overrides while this file
+stays common across all of them.
+
+@~/.claude/CLAUDE.local.md


### PR DESCRIPTION
Kicks off Claude-related config in the dotfiles repo.

## What

- Adds `claude/CLAUDE.md` — global instructions for Claude Code.
- Wires it into the `Makefile` `CONFIGS` list so `make install` symlinks it to `~/.claude/CLAUDE.md` (Claude Code's global memory), following the repo's existing dotfile pattern.

## Content

The initial instructions cover how to work with **zmx** (persistent detached terminal sessions):

- Check `zmx help` for current syntax before use.
- Prefix agent-spawned sessions with `ai.` and scope them per feature (`ai.feature-x`, `ai.feature-x.tests`).
- Clean up only the relevant session group, never the user's own sessions.
- Apply the same rules on remote machines.

## Verification

`make -n install` confirms the entry expands to `ln -sf $(PWD)/claude/CLAUDE.md ~/.claude/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcTtdz9tLB5uCKwJZCoCwR)_