### PR TITLE
zsh prompt: move zmx session badge to the left

### DIFF
--- a/zshprompt
+++ b/zshprompt
@@ -177,10 +177,10 @@ add-zsh-hook chpwd gitinfo_update
 add-zsh-hook preexec gitinfo_preexec
 add-zsh-hook precmd gitinfo_precmd
 
-PS1='%F{yellow}[%T%F{cyan}%1(j.%%%F{green}%j%F{cyan}.)%0(?..:%F{red}%B%?%b)%F{yellow}]%F{cyan}%# %f'
-zmx_rps=""
+zmx_ps=""
 if [[ -n $ZMX_SESSION ]]; then
-	zmx_rps="%F{magenta}[${ZMX_SESSION#$ZMX_SESSION_PREFIX}]%f "
+	zmx_ps="%F{magenta}[${ZMX_SESSION#$ZMX_SESSION_PREFIX}]%f "
 fi
-RPS1='${zmx_rps}%100>..>%F{cyan}%n%f%B@%b%F{cyan}%m%f%B:%b%<<%F{cyan}$(git_path)$gitinfo[msg]%b%k%f'
+PS1='${zmx_ps}%F{yellow}[%T%F{cyan}%1(j.%%%F{green}%j%F{cyan}.)%0(?..:%F{red}%B%?%b)%F{yellow}]%F{cyan}%# %f'
+RPS1='%100>..>%F{cyan}%n%f%B@%b%F{cyan}%m%f%B:%b%<<%F{cyan}$(git_path)$gitinfo[msg]%b%k%f'
 


### PR DESCRIPTION
## Summary
Moves the zmx session badge from the right side of the zsh prompt to the far left, which is the conventional placement.

Previously the badge (`[session-name]`) prefixed `RPS1`, so it rendered on the right-hand side of the prompt line. Now it prefixes `PS1`, rendering at the very start of the line before the `[time]%` prompt.

## Change
In `zshprompt`, the `zmx_ps` (was `zmx_rps`) assignment block moved above the `PS1` definition so the variable is defined before use, and the `${zmx_ps}` reference moved from the start of `RPS1` to the start of `PS1`.

## Verification
Sourced `zshprompt` in a subshell with `ZMX_SESSION=d.myproject` and `prompt_subst` set; the rendered left prompt is `[myproject]` (magenta) followed by the usual `[time]%` prompt, and the badge no longer appears in `RPS1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)