### PR TITLE
Generalize agent instructions: CLAUDE.md -> AGENTS.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ DEST = $(HOME)
 CONFIGS = \
 Xdefaults \
 Xmodmap \
-claude/CLAUDE.md \
 config/awesome/rc.lua \
 config/ghostty/config \
 gitconfig \
@@ -37,12 +36,27 @@ ZSHBUNDLES = $(patsubst %,zsh/func/%/.git,$(ZSHBUNDLEFILES))
 
 all: build
 
-install: build $(TARGETS) $(DEST)/.claude/CLAUDE.local.md
+install: build $(TARGETS) $(DEST)/AGENTS.md $(DEST)/.claude/CLAUDE.md $(DEST)/AGENTS.local.md
 
-# Per-machine Claude instructions, imported by ~/.claude/CLAUDE.md.
-# Created empty when absent and never overwritten, so each machine keeps
-# its own overrides.
-$(DEST)/.claude/CLAUDE.local.md:
+# Shared, agent-agnostic instructions. agents/AGENTS.md is the single
+# source of truth; the locations different agents look for are symlinked
+# to it here.
+#
+# - ~/AGENTS.md          : the emerging cross-agent convention (Codex, pi, ...)
+# - ~/.claude/CLAUDE.md  : Claude Code still looks here
+$(DEST)/AGENTS.md: agents/AGENTS.md
+	@mkdir -p $(dir $@)
+	@[ ! -e $@ ] || [ -h $@ ] || mv -f $@ $@.bak
+	ln -sf $(PWD)/agents/AGENTS.md $@
+
+$(DEST)/.claude/CLAUDE.md: agents/AGENTS.md
+	@mkdir -p $(dir $@)
+	@[ ! -e $@ ] || [ -h $@ ] || mv -f $@ $@.bak
+	ln -sf $(PWD)/agents/AGENTS.md $@
+
+# Per-machine instructions, imported by AGENTS.md. Created empty when
+# absent and never overwritten, so each machine keeps its own overrides.
+$(DEST)/AGENTS.local.md:
 	@mkdir -p $(dir $@)
 	touch $@
 

--- a/agents/AGENTS.md
+++ b/agents/AGENTS.md
@@ -1,4 +1,9 @@
-# Global instructions for Claude Code
+# Global instructions for coding agents
+
+These are agent-agnostic instructions shared across whatever coding
+agent I happen to be using (Claude Code, Codex, pi, etc.). This file is
+the single source of truth; per-agent config locations are symlinked to
+it by `make install`.
 
 ## Terminal sessions: use zmx
 
@@ -23,9 +28,9 @@ Remote machines:
 ## Machine-specific instructions
 
 Anything specific to one machine — work setup on a dev box, personal
-setup on a laptop — goes in `~/.claude/CLAUDE.local.md`, which is not
-tracked in this repo. `make install` creates it empty and never
-overwrites it, so each machine keeps its own overrides while this file
-stays common across all of them.
+setup on a laptop — goes in `~/AGENTS.local.md`, which is not tracked in
+this repo. `make install` creates it empty and never overwrites it, so
+each machine keeps its own overrides while this file stays common across
+all of them.
 
-@~/.claude/CLAUDE.local.md
+@~/AGENTS.local.md


### PR DESCRIPTION
Moves the dotfiles away from a Claude-specific setup toward an agent-agnostic one.

## What changed
- Renamed `claude/CLAUDE.md` -> `agents/AGENTS.md` as the single source of truth for global coding-agent instructions.
- Reworded the content to be agent-agnostic (no longer assumes Claude), and pointed per-machine overrides at `~/AGENTS.local.md`.
- `make install` now symlinks the shared file to:
  - `~/AGENTS.md` — the emerging cross-agent convention (Codex, pi, ...)
  - `~/.claude/CLAUDE.md` — Claude Code still reads this
  and creates an empty, never-overwritten `~/AGENTS.local.md`.

## Migration
After merging, run `make install`. The old `~/.claude/CLAUDE.md` symlink and any `~/.claude/CLAUDE.local.md` are superseded by the new `AGENTS.md` layout.