### PR TITLE
zsh: stop prefixing zmx sessions with ZMX_SESSION_PREFIX

### DIFF
--- a/zshenv
+++ b/zshenv
@@ -3,7 +3,6 @@ if [ -x /usr/libexec/path_helper ]; then
 fi
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
-export ZMX_SESSION_PREFIX="d."
 
 fpath=($fpath $HOME/.zsh/func)
 for f in $HOME/.zsh/func/* $HOME/.zsh/func/*/*; do

--- a/zshprompt
+++ b/zshprompt
@@ -179,7 +179,7 @@ add-zsh-hook precmd gitinfo_precmd
 
 zmx_ps=""
 if [[ -n $ZMX_SESSION ]]; then
-	zmx_ps="%F{magenta}[${ZMX_SESSION#$ZMX_SESSION_PREFIX}]%f "
+	zmx_ps="%F{magenta}[${ZMX_SESSION}]%f "
 fi
 PS1='${zmx_ps}%F{yellow}[%T%F{cyan}%1(j.%%%F{green}%j%F{cyan}.)%0(?..:%F{red}%B%?%b)%F{yellow}]%F{cyan}%# %f'
 RPS1='%100>..>%F{cyan}%n%f%B@%b%F{cyan}%m%f%B:%b%<<%F{cyan}$(git_path)$gitinfo[msg]%b%k%f'


### PR DESCRIPTION
## Summary

`zmx` was auto-prefixing every session name with `d.` because of `ZMX_SESSION_PREFIX="d."` in `zshenv` (added in 2b24bad). The prompt then stripped that prefix back off for display, so the two mechanisms only existed to cancel each other out.

This removes the prefixing entirely:
- Delete `export ZMX_SESSION_PREFIX="d."` from `zshenv`
- Simplify the prompt badge to show the raw `$ZMX_SESSION` (no more `${ZMX_SESSION#$ZMX_SESSION_PREFIX}` stripping)

## Notes

Existing sessions created while the prefix was set will still carry their `d.` names until recreated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)